### PR TITLE
Fix over-decrementing count bug.

### DIFF
--- a/AATree.m
+++ b/AATree.m
@@ -378,13 +378,14 @@
 				aRoot.left = [self __deleteNodeAtKey:aRoot.key atRoot:aRoot.left];
                 aRoot.left.parent = aRoot;
 				
-			} else if (aRoot.left) {
-				aRoot = aRoot.left;
 			} else {
-				aRoot = aRoot.right; // which could be nil.
+				if (aRoot.left) {
+					aRoot = aRoot.left;
+				} else {
+					aRoot = aRoot.right; // which could be nil.
+				}
+				count--;
 			}
-			
-			count--;
 
 		// Otherwise, travel left or right.
 		} else if (compareResult == NSOrderedAscending) {


### PR DESCRIPTION
See issue #1.

`__deleteNodeAtKey:atRoot:` decremented count both when replacing a node with one of its descendants and also when removing that descendant.